### PR TITLE
Add support for exposing multiple service ports

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: app
 description: Generic app chart
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/charts/app/templates/deployment.yaml
+++ b/charts/app/templates/deployment.yaml
@@ -57,7 +57,10 @@ spec:
                   key: {{ $v | quote }}
           {{- end }}
           ports:
-            - containerPort: {{ .Values.global.service.port }}
+            {{- range $name, $port := .Values.global.service.ports }}
+            - containerPort: {{ $port }}
+              name: {{ $name }}
+            {{- end }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.global.healthProbe.initialDelaySeconds }}
             httpGet:

--- a/charts/app/templates/service.yaml
+++ b/charts/app/templates/service.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   type: {{ .Values.global.service.type }}
   ports:
-    - port: {{ .Values.global.service.port }}
-      name: http
+    {{- range $name, $port := .Values.global.service.ports }}
+    - port: {{ $port }}
+      name: {{ $name }}
+    {{- end }}
   selector:
     {{- include "app.selectorLabels" . | nindent 4 }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -46,7 +46,8 @@ global:
 
   service:
     type: ClusterIP
-    port: 8080
+    ports:
+      http: 8080
 
   healthProbe:
     port: 8081


### PR DESCRIPTION
I rolled back all previous changes, leaving only multiple ports support.